### PR TITLE
/DevIL/include/IL/il.h: update ifdef condition for MCST-LCC compiler

### DIFF
--- a/DevIL/include/IL/il.h
+++ b/DevIL/include/IL/il.h
@@ -456,7 +456,7 @@ typedef long long unsigned int ILuint64;
 //
 
 // This is from Win32's <windef.h>
-#if (_MSC_VER >= 800) || defined(_STDCALL_SUPPORTED) || defined(__BORLANDC__) || defined(__LCC__) && !defined(__e2k__)
+#if (_MSC_VER >= 800) || defined(_STDCALL_SUPPORTED) || defined(__BORLANDC__) || defined(__LCC__) && !defined(__MCST__)
 	#define ILAPIENTRY __stdcall 
 	#define IL_PACKSTRUCT
 //#elif defined(linux) || defined(MACOSX) || defined(__CYGWIN__) //fix bug 840364
@@ -475,7 +475,7 @@ typedef long long unsigned int ILuint64;
 #endif
 
 // This is from Win32's <wingdi.h> and <winnt.h>
-#if defined(__LCC__) && !defined(__e2k__)
+#if defined(__LCC__) && !defined(__MCST__)
 	#define ILAPI __stdcall
 #elif defined(_WIN32) //changed 20031221 to fix bug 840421
 	#ifdef IL_STATIC_LIB


### PR DESCRIPTION
in mcst-lcc compiler => 1.25 added a new macro definition to determine compiler

enhancement of the previous patch - https://github.com/spring/DevIL/pull/1